### PR TITLE
Alter timeout for send_message  and Agent Stop method

### DIFF
--- a/lib/swarm_ex.ex
+++ b/lib/swarm_ex.ex
@@ -111,7 +111,7 @@ defmodule SwarmEx do
   @spec send_message_to_pid(pid(), message()) :: response()
   def send_message_to_pid(agent_pid, message) when is_pid(agent_pid) do
     try do
-      GenServer.call(agent_pid, {:message, message})
+      GenServer.call(agent_pid, {:message, message}, :infinity)
     catch
       :exit, reason ->
         {:error,

--- a/lib/swarm_ex/agent.ex
+++ b/lib/swarm_ex/agent.ex
@@ -224,7 +224,7 @@ defmodule SwarmEx.Agent do
       @spec send_message(pid() | atom() | String.t(), term()) ::
               {:ok, term()} | {:error, term()}
       def send_message(agent, message) do
-        GenServer.call(via_tuple(agent), {:message, message})
+        GenServer.call(via_tuple(agent), {:message, message}, :infinity)
       end
 
       @spec get_state(pid() | atom() | String.t()) ::

--- a/lib/swarm_ex/agent.ex
+++ b/lib/swarm_ex/agent.ex
@@ -605,7 +605,9 @@ defmodule SwarmEx.Agent do
   @spec stop(pid() | atom() | binary(), term()) :: :ok | {:error, term()}
   def stop(agent, reason \\ :normal) do
     try do
-      GenServer.stop(via_tuple(agent), reason)
+      if pid = GenServer.whereis(via_tuple(agent)) do
+        DynamicSupervisor.terminate_child(SwarmEx.AgentSupervisor, pid)
+      end
     catch
       :exit, {:noproc, _} ->
         {:error,

--- a/lib/swarm_ex/client.ex
+++ b/lib/swarm_ex/client.ex
@@ -85,7 +85,7 @@ defmodule SwarmEx.Client do
   @spec send_message(GenServer.server(), agent_id(), term()) ::
           {:ok, term()} | {:error, term()}
   def send_message(client, agent_id, message) do
-    GenServer.call(client, {:send_message, agent_id, message})
+    GenServer.call(client, {:send_message, agent_id, message}, :infinity)
   end
 
   @doc """
@@ -151,7 +151,7 @@ defmodule SwarmEx.Client do
   def handle_call({:send_message, agent_id, message}, _from, state) do
     case Map.fetch(state.active_agents, agent_id) do
       {:ok, pid} ->
-        result = GenServer.call(pid, {:message, message})
+        result = GenServer.call(pid, {:message, message}, :infinity)
         {:reply, result, state}
 
       :error ->


### PR DESCRIPTION


As an agent framework for LLM, for current large models, the `send_message` and `handle_message` may be time-consuming depending on the input context. The default 5-second timeout is clearly inappropriate.

I also adjusted the agent's stop method to ensure that DynamicSupervisor properly terminates its child processes.